### PR TITLE
Modify options to allow boolean 'removeExtension'

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,6 +37,7 @@ module.exports = function(grunt) {
       custom_options: {
         options: {
           basePath: 'test/fixtures/',
+          removeExtension:true,
           property: {
             parent: 'app'
           }

--- a/tasks/ractive_compile.js
+++ b/tasks/ractive_compile.js
@@ -23,6 +23,11 @@ module.exports = function(grunt) {
         f.src.forEach(function(filePath) {
             var html = grunt.file.read(filePath);
             var template = ractive.parse(html);
+
+            if(options.removeExtension) {
+                filePath = filePath.replace(/\.[^/.]+$/, "");
+            }
+
             if(options.basePath) {
               templates[filePath.replace(new RegExp('^' + options.basePath), '')] = template;
             } else {


### PR DESCRIPTION
Ran into a problem trying to use Ractive.partials. I assigned the output of the ractive-compile directly to Ractive.partials, but was unable to reference any of them. Ractive fails trying to access the array due to the period in the name.

Plus, it might be nice to not have to reference them with file extensions. We use .mustache for our templates and it can be very tedious trying to do this all the time.
